### PR TITLE
fixed linting errors 1039 unnecessary fmt

### DIFF
--- a/client/service/client.go
+++ b/client/service/client.go
@@ -5,13 +5,14 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"github.com/google/go-querystring/query"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"net/url"
 	"reflect"
 	"time"
+
+	"github.com/google/go-querystring/query"
 )
 
 // CloudServiceProvider is a custom type for different types of cloud service providers
@@ -93,7 +94,7 @@ func (c DBApiClientConfig) getAuthHeader() map[string]string {
 func (c DBApiClientConfig) getUserAgentHeader() map[string]string {
 	if reflect.ValueOf(c.UserAgent).IsZero() {
 		return map[string]string{
-			"User-Agent": fmt.Sprintf("databricks-go-client-sdk"),
+			"User-Agent": "databricks-go-client-sdk",
 		}
 	}
 	return map[string]string{

--- a/client/service/dbfs_test.go
+++ b/client/service/dbfs_test.go
@@ -3,9 +3,10 @@ package service
 import (
 	"encoding/base64"
 	"fmt"
-	"github.com/databrickslabs/databricks-terraform/client/model"
 	"net/http"
 	"testing"
+
+	"github.com/databrickslabs/databricks-terraform/client/model"
 )
 
 var base64String = base64.StdEncoding.EncodeToString([]byte("helloworld"))
@@ -323,10 +324,10 @@ func TestDBFSAPI_Read(t *testing.T) {
 					"bytes_read": 1000000,
 					"data": "%s"
 				}`, base64String),
-				fmt.Sprintf(`{
+				`{
 					"bytes_read": 0,
 					"data": ""
-				}`),
+				}`,
 			},
 			responseStatus: []int{http.StatusOK, http.StatusOK},
 			requestMethod:  []string{http.MethodGet, http.MethodGet},
@@ -360,10 +361,10 @@ func TestDBFSAPI_Read(t *testing.T) {
 					"bytes_read": 1000000,
 					"data": "%s"
 				}`, base64String),
-				fmt.Sprintf(`{
+				`{
 					"bytes_read": 0,
 					"data": ""
-				}`),
+				}`,
 			},
 			responseStatus: []int{http.StatusOK, http.StatusBadRequest},
 			requestMethod:  []string{http.MethodGet, http.MethodGet},


### PR DESCRIPTION
Fixed 3 linting errors that were causing `make build` to fail: `S1039: unnecessary use of fmt.Sprintf (gosimple)`