### PR TITLE
Fix for #47: notebook content state func is called at the wrong time

### DIFF
--- a/databricks/resource_databricks_notebook.go
+++ b/databricks/resource_databricks_notebook.go
@@ -7,10 +7,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"github.com/databrickslabs/databricks-terraform/client/model"
-	"github.com/databrickslabs/databricks-terraform/client/service"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"hash/crc32"
 	"io"
 	"log"
@@ -18,6 +14,11 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/databrickslabs/databricks-terraform/client/model"
+	"github.com/databrickslabs/databricks-terraform/client/service"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 )
 
 func resourceNotebook() *schema.Resource {
@@ -28,17 +29,10 @@ func resourceNotebook() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"content": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-				StateFunc: func(i interface{}) string {
-					base64String := i.(string)
-					base64, err := convertBase64ToCheckSum(base64String)
-					if err != nil {
-						panic(err)
-					}
-					return base64
-				},
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringIsBase64,
 			},
 			"path": &schema.Schema{
 				Type:     schema.TypeString,
@@ -185,6 +179,7 @@ func resourceNotebookDelete(d *schema.ResourceData, m interface{}) error {
 func convertBase64ToCheckSum(b64 string) (string, error) {
 	dataArr, err := base64.StdEncoding.DecodeString(b64)
 	if err != nil {
+		log.Printf("Error while trying to decode base64 content: %v\n", err)
 		return "error", err
 	}
 	checksum, err := convertZipBytesToCRC(dataArr)

--- a/databricks/resource_databricks_notebook.go
+++ b/databricks/resource_databricks_notebook.go
@@ -29,9 +29,17 @@ func resourceNotebook() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"content": &schema.Schema{
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				StateFunc: func(i interface{}) string {
+					base64String := i.(string)
+					base64, err := convertBase64ToCheckSum(base64String)
+					if err != nil {
+						return ""
+					}
+					return base64
+				},
 				ValidateFunc: validation.StringIsBase64,
 			},
 			"path": &schema.Schema{


### PR DESCRIPTION
The state func in the content argument for the notebook resource was called during the plan phase. Because I was using a templatefile with a dependency, the computed value was not available yet.

The state func got a guid instead of a base64 string so it fails to parse it (probably because the content is not available yet?)

The validation func should correctly verify if it's a valid base64 string and seems to handle the edge cases of when the value is not computed yet.

This fixes #47 

Maybe could you let me know why the state func was there in the first place? Thanks!