### PR TITLE
Documentation updates for correctness and demonstration 

### DIFF
--- a/databricks/resource_databricks_cluster.go
+++ b/databricks/resource_databricks_cluster.go
@@ -109,6 +109,7 @@ func resourceCluster() *schema.Resource {
 				Type:          schema.TypeString,
 				Optional:      true,
 				ConflictsWith: []string{"instance_pool_id"},
+				AtLeastOneOf:  []string{"instance_pool_id"},
 			},
 			"ssh_public_keys": &schema.Schema{
 				Type:     schema.TypeSet,
@@ -300,6 +301,7 @@ func resourceCluster() *schema.Resource {
 				Type:          schema.TypeString,
 				Optional:      true,
 				ConflictsWith: []string{"node_type_id", "driver_node_type_id", "aws_attributes"},
+				AtLeastOneOf:  []string{"node_type_id"},
 			},
 			"idempotency_token": &schema.Schema{
 				Type:     schema.TypeInt,

--- a/databricks/resource_databricks_notebook.go
+++ b/databricks/resource_databricks_notebook.go
@@ -75,6 +75,7 @@ func resourceNotebook() *schema.Resource {
 				ForceNew: true,
 				ValidateFunc: validation.StringInSlice([]string{
 					string(model.DBC),
+					string(model.Jupyter),
 					string(model.Source),
 					string(model.HTML),
 				}, false),

--- a/website/content/Resources/cluster.md
+++ b/website/content/Resources/cluster.md
@@ -27,6 +27,8 @@ resource "databricks_cluster" "my-cluster" {
 }
 ```  
 
+>Note: For Azure, valid node_type_ids are the "Sizes" of the virtual machines to use as workers, e.g. Standard_DS3_v2.
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -64,7 +66,7 @@ overloaded. max_workers must be strictly greater than min_workers.
 If not specified at creation, the cluster name will be an empty string.
 
 #### - `spark_version`:
-> **(Optional)** 	The Spark version of the cluster. A list of available 
+> **(Required)** 	The Spark version of the cluster. A list of available 
 Spark versions can be retrieved by using the Runtime Versions API call. This field is required.
 
 #### - `spark_conf`:
@@ -144,7 +146,7 @@ value must be within the range 500 - 4096. Custom EBS volumes cannot be specifie
 is optional; if unset, the driver node type will be set as the same value as node_type_id defined above.
 
 #### - `node_type_id`:
-> **(Optional)** This field encodes, through a single value, the resources 
+> **(Required)** This field encodes, through a single value, the resources 
 available to each of the Spark nodes in this cluster. For example, the Spark nodes can be provisioned and optimized for 
 memory or compute intensive workloads A list of available node types can be retrieved by using the List Node Types API 
 call. This field is required.

--- a/website/content/Resources/cluster.md
+++ b/website/content/Resources/cluster.md
@@ -146,7 +146,7 @@ value must be within the range 500 - 4096. Custom EBS volumes cannot be specifie
 is optional; if unset, the driver node type will be set as the same value as node_type_id defined above.
 
 #### - `node_type_id`:
-> **(Required)** This field encodes, through a single value, the resources 
+> **(Optional - required if instance_pool_id is not given)** This field encodes, through a single value, the resources 
 available to each of the Spark nodes in this cluster. For example, the Spark nodes can be provisioned and optimized for 
 memory or compute intensive workloads A list of available node types can be retrieved by using the List Node Types API 
 call. This field is required.
@@ -324,7 +324,7 @@ this cluster dynamically acquires additional disk space when its Spark workers a
 feature requires specific AWS permissions to function correctly - refer to Autoscaling local storage for details.
 
 #### - `instance_pool_id`:
-> **(Optional)** The optional ID of the instance pool to which the 
+> **(Optional - required if node_type_id is not given)** The optional ID of the instance pool to which the 
 cluster belongs. Refer to Instance Pools API for details.
 
 #### - `single_user_name`:

--- a/website/content/Resources/notebook.md
+++ b/website/content/Resources/notebook.md
@@ -24,11 +24,11 @@ resource "databricks_notebook" "my_databricks_notebook" {
 }
 ```
 
-For deployment of a plain Python notebook, the following example might be useful:
+For deployment of an empty Python notebook, the following example might be useful:
 
 ```hcl
 resource "databricks_notebook" "notebook" {
-  content = base64encode("# Welcome to your Jupyter notebook")
+  content = base64encode("# Welcome to your Python notebook")
   path = "/mynotebook"
   overwrite = false
   mkdirs = true
@@ -64,7 +64,7 @@ returns an error RESOURCE_ALREADY_EXISTS. If this operation fails it may have su
 
 #### - `format`:
 > **(Required)** This specifies the format of the file to be imported. 
-By default, this is SOURCE. However it may be one of: SOURCE, HTML, or DBC. The value is case sensitive. SOURCE is used for deployment of, for example, Python notebooks.
+By default, this is SOURCE (meaning code). However it may be one of: SOURCE, HTML, or DBC. The value is case sensitive. SOURCE is used for deployment of, for example, Python notebooks.
 
 ## Attribute Reference
 

--- a/website/content/Resources/notebook.md
+++ b/website/content/Resources/notebook.md
@@ -64,7 +64,7 @@ returns an error RESOURCE_ALREADY_EXISTS. If this operation fails it may have su
 
 #### - `format`:
 > **(Required)** This specifies the format of the file to be imported. 
-By default, this is SOURCE. However it may be one of: SOURCE, HTML, JUPYTER, DBC. The value is case sensitive.
+By default, this is SOURCE. However it may be one of: SOURCE, HTML, JUPYTER, DBC. The value is case sensitive. Note: For Azure, JUPYTER differs from other options in producing a notebook in a file format supported by the [workspace import and export API](https://docs.microsoft.com/en-us/azure/databricks/dev-tools/api/latest/workspace#--request-structure-1).
 
 ## Attribute Reference
 

--- a/website/content/Resources/notebook.md
+++ b/website/content/Resources/notebook.md
@@ -64,7 +64,7 @@ returns an error RESOURCE_ALREADY_EXISTS. If this operation fails it may have su
 
 #### - `format`:
 > **(Required)** This specifies the format of the file to be imported. 
-By default, this is SOURCE. However it may be one of: SOURCE, HTML, JUPYTER, DBC. The value is case sensitive. Note: For Azure, JUPYTER differs from other options in producing a notebook in a file format supported by the [workspace import and export API](https://docs.microsoft.com/en-us/azure/databricks/dev-tools/api/latest/workspace#--request-structure-1).
+By default, this is SOURCE. However it may be one of: SOURCE, HTML, JUPYTER, DBC. The value is case sensitive. SOURCE is suitable for .scala, .py, .r, .sql extension based files, HTML for .html files, JUPYTER for .ipynb files, and DBC for .dbc files.
 
 ## Attribute Reference
 

--- a/website/content/Resources/notebook.md
+++ b/website/content/Resources/notebook.md
@@ -64,7 +64,7 @@ returns an error RESOURCE_ALREADY_EXISTS. If this operation fails it may have su
 
 #### - `format`:
 > **(Required)** This specifies the format of the file to be imported. 
-By default, this is SOURCE (meaning code). However it may be one of: SOURCE, HTML, or DBC. The value is case sensitive. SOURCE is used for deployment of, for example, Python notebooks.
+By default, this is SOURCE. However it may be one of: SOURCE, HTML, JUPYTER, DBC. The value is case sensitive.
 
 ## Attribute Reference
 

--- a/website/content/Resources/notebook.md
+++ b/website/content/Resources/notebook.md
@@ -23,6 +23,19 @@ resource "databricks_notebook" "my_databricks_notebook" {
   format = "DBC"
 }
 ```
+
+For deployment of a plain Python notebook, the following example might be useful:
+
+```hcl
+resource "databricks_notebook" "notebook" {
+  content = base64encode("# Welcome to your Jupyter notebook")
+  path = "/mynotebook"
+  overwrite = false
+  mkdirs = true
+  language = "PYTHON"
+  format = "SOURCE"
+}
+```
     
 ## Argument Reference
 
@@ -33,7 +46,7 @@ The following arguments are supported:
 exception with error code MAX_NOTEBOOK_SIZE_EXCEEDED will be thrown.
 
 #### - `path`:
-> **(Required)** The absolute path of the notebook or directory. 
+> **(Required)** The absolute path of the notebook or directory, beginning with "/", e.g. "/mynotebook"
 Exporting a directory is supported only for DBC. This field is **required**.
 
 #### - `language`:
@@ -51,7 +64,7 @@ returns an error RESOURCE_ALREADY_EXISTS. If this operation fails it may have su
 
 #### - `format`:
 > **(Required)** This specifies the format of the file to be imported. 
-By default, this is SOURCE. However it may be one of: SOURCE, HTML, JUPYTER, DBC. The value is case sensitive.
+By default, this is SOURCE. However it may be one of: SOURCE, HTML, or DBC. The value is case sensitive. SOURCE is used for deployment of, for example, Python notebooks.
 
 ## Attribute Reference
 


### PR DESCRIPTION
Hey! ✌️

Made the following changes to update the docs and smooth adoption for people, especially those hoping to use their deployed resources for Python notebooks, and deploying clusters to Azure:

- Update `spark_version` cluster resource parameter to "required"
- Update `node_type_id` cluster resource parameter to "required"
- Remove JUPYTER from the documented notebook format types. It was rejected when I used it, but SOURCE worked just fine for Python.
- Add example to notebook documentation for quick deployment of an empty Python notebook (common use case)
- Note that "absolute path" to deployed notebooks is not a regular file system path, but must start specifically with "/", giving an example for a notebook.