### PR TITLE
Avoid accidental workspace creation

### DIFF
--- a/client/service/apis.go
+++ b/client/service/apis.go
@@ -99,9 +99,11 @@ func (c DBApiClient) Commands() CommandsAPI {
 }
 
 func (c *DBApiClient) performQuery(method, path string, apiVersion string, headers map[string]string, data interface{}, secretsMask *SecretsMask) ([]byte, error) {
-	err := c.EnsureConfig(c)
-	if err != nil {
-		return []byte{}, err
+	if c.EnsureConfig != nil {
+		err := c.EnsureConfig(c)
+		if err != nil {
+			return []byte{}, err
+		}
 	}
 	return PerformQuery(c.Config, method, path, apiVersion, headers, true, false, data, secretsMask)
 }

--- a/databricks/azure_auth.go
+++ b/databricks/azure_auth.go
@@ -156,7 +156,7 @@ func (a *AzureAuth) getWorkspaceAccessToken(config *service.DBApiClientConfig) e
 	resp, err := service.PerformQuery(config, http.MethodPost, url, "2.0", headers, true, true, payload, nil)
 	if err != nil {
 		var dbApiError service.DBApiError
-		if errors.As(err, dbApiError) && dbApiError.StatusCode == 404 {
+		if errors.As(err, &dbApiError) && dbApiError.StatusCode == 404 {
 			return &service.WorkspaceDoesNotExistError{
 				WorkspaceID: a.AdbWorkspaceResourceID,
 				Err:         err,
@@ -181,10 +181,6 @@ func (a *AzureAuth) initWorkspaceAndGetClient(config *service.DBApiClientConfig)
 	return service.DBApiClient{
 		EnsureConfig: func(dbClient *service.DBApiClient) error {
 			log.Print("azure_auth: EnsureConfig\n")
-			if dbClient == nil {
-				log.Print("Ooops!!!!!!!!!!!!!!!!!!!!!\n")
-				return fmt.Errorf("Got a nil dbClient")
-			}
 			if dbClient.Config != nil && dbClient.Config.Token != "" {
 				// Have a token set - no more to do
 				log.Print("azure_auth: Azure client already initialized\n")


### PR DESCRIPTION
Avoid accidental workspace creation as per discussion in #54.
Update to handle `terraform plan` when the workspace doesn't yet exist by adding an `EnsureConfig` function on the client that is called before performing a query. This is set in the `azure_auth` provider to ensure that we have a token and to generate it if not.

Fixes #54