### PR TITLE
Fix azure workspace creation bug

### DIFF
--- a/client/service/apis.go
+++ b/client/service/apis.go
@@ -17,22 +17,22 @@ func (c *DBApiClient) SetConfig(clientConfig *DBApiClientConfig) DBApiClient {
 }
 
 // Clusters returns an instance of ClustersAPI
-func (c DBApiClient) Clusters() ClustersAPI {
+func (c *DBApiClient) Clusters() ClustersAPI {
 	return ClustersAPI{Client: c}
 }
 
 // Secrets returns an instance of SecretsAPI
-func (c DBApiClient) Secrets() SecretsAPI {
+func (c *DBApiClient) Secrets() SecretsAPI {
 	return SecretsAPI{Client: c}
 }
 
 // SecretScopes returns an instance of SecretScopesAPI
-func (c DBApiClient) SecretScopes() SecretScopesAPI {
+func (c *DBApiClient) SecretScopes() SecretScopesAPI {
 	return SecretScopesAPI{Client: c}
 }
 
 // SecretAcls returns an instance of SecretAclsAPI
-func (c DBApiClient) SecretAcls() SecretAclsAPI {
+func (c *DBApiClient) SecretAcls() SecretAclsAPI {
 	return SecretAclsAPI{Client: c}
 }
 
@@ -42,50 +42,54 @@ func (c *DBApiClient) Tokens() TokensAPI {
 }
 
 // Users returns an instance of UsersAPI
-func (c DBApiClient) Users() UsersAPI {
+func (c *DBApiClient) Users() UsersAPI {
 	return UsersAPI{Client: c}
 }
 
 // Groups returns an instance of GroupsAPI
-func (c DBApiClient) Groups() GroupsAPI {
+func (c *DBApiClient) Groups() GroupsAPI {
 	return GroupsAPI{Client: c}
 }
 
 // Notebooks returns an instance of NotebooksAPI
-func (c DBApiClient) Notebooks() NotebooksAPI {
+func (c *DBApiClient) Notebooks() NotebooksAPI {
 	return NotebooksAPI{Client: c}
 }
 
 // Jobs returns an instance of JobsAPI
-func (c DBApiClient) Jobs() JobsAPI {
+func (c *DBApiClient) Jobs() JobsAPI {
 	return JobsAPI{Client: c}
 }
 
 // DBFS returns an instance of DBFSAPI
-func (c DBApiClient) DBFS() DBFSAPI {
+func (c *DBApiClient) DBFS() DBFSAPI {
 	return DBFSAPI{Client: c}
 }
 
 // Libraries returns an instance of LibrariesAPI
-func (c DBApiClient) Libraries() LibrariesAPI {
+func (c *DBApiClient) Libraries() LibrariesAPI {
 	return LibrariesAPI{Client: c}
 }
 
 // InstancePools returns an instance of InstancePoolsAPI
-func (c DBApiClient) InstancePools() InstancePoolsAPI {
+func (c *DBApiClient) InstancePools() InstancePoolsAPI {
 	return InstancePoolsAPI{Client: c}
 }
 
 // InstanceProfiles returns an instance of InstanceProfilesAPI
-func (c DBApiClient) InstanceProfiles() InstanceProfilesAPI {
+func (c *DBApiClient) InstanceProfiles() InstanceProfilesAPI {
 	return InstanceProfilesAPI{Client: c}
 }
 
 // Commands returns an instance of CommandsAPI
-func (c DBApiClient) Commands() CommandsAPI {
+func (c *DBApiClient) Commands() CommandsAPI {
 	return CommandsAPI{Client: c}
 }
 
-func (c DBApiClient) performQuery(method, path string, apiVersion string, headers map[string]string, data interface{}, secretsMask *SecretsMask) ([]byte, error) {
+func (c *DBApiClient) performQuery(method, path string, apiVersion string, headers map[string]string, data interface{}, secretsMask *SecretsMask) ([]byte, error) {
+	err := c.Config.getOrCreateToken()
+	if err != nil {
+		return []byte(""), err
+	}
 	return PerformQuery(c.Config, method, path, apiVersion, headers, true, false, data, secretsMask)
 }

--- a/client/service/clusters.go
+++ b/client/service/clusters.go
@@ -11,7 +11,7 @@ import (
 
 // ClustersAPI is a struct that contains the Databricks api client to perform queries
 type ClustersAPI struct {
-	Client DBApiClient
+	Client *DBApiClient
 }
 
 // Create creates a new Spark cluster

--- a/client/service/commands.go
+++ b/client/service/commands.go
@@ -12,7 +12,7 @@ import (
 
 // CommandsAPI exposes the Context & Commands API
 type CommandsAPI struct {
-	Client DBApiClient
+	Client *DBApiClient
 }
 
 // Execute creates a spark context and executes a command and then closes context

--- a/client/service/dbfs.go
+++ b/client/service/dbfs.go
@@ -10,7 +10,7 @@ import (
 
 // DBFSAPI exposes the DBFS API
 type DBFSAPI struct {
-	Client DBApiClient
+	Client *DBApiClient
 }
 
 // Create creates a file in DBFS given data string in base64

--- a/client/service/groups.go
+++ b/client/service/groups.go
@@ -12,7 +12,7 @@ import (
 
 // GroupsAPI exposes the scim groups API
 type GroupsAPI struct {
-	Client DBApiClient
+	Client *DBApiClient
 }
 
 // Create creates a scim group in the Databricks workspace

--- a/client/service/instance_pools.go
+++ b/client/service/instance_pools.go
@@ -8,7 +8,7 @@ import (
 
 // InstancePoolsAPI exposes the instance pools api
 type InstancePoolsAPI struct {
-	Client DBApiClient
+	Client *DBApiClient
 }
 
 // Create creates the instance pool to given the instance pool configuration

--- a/client/service/instance_profiles.go
+++ b/client/service/instance_profiles.go
@@ -9,7 +9,7 @@ import (
 
 // InstanceProfilesAPI exposes the instance profiles api on the AWS deployment of Databricks
 type InstanceProfilesAPI struct {
-	Client DBApiClient
+	Client *DBApiClient
 }
 
 // Create creates an instance profile record on Databricks

--- a/client/service/jobs.go
+++ b/client/service/jobs.go
@@ -8,7 +8,7 @@ import (
 
 // JobsAPI exposes the Jobs API
 type JobsAPI struct {
-	Client DBApiClient
+	Client *DBApiClient
 }
 
 // Create creates a job on the workspace given the job settings

--- a/client/service/libraries.go
+++ b/client/service/libraries.go
@@ -8,7 +8,7 @@ import (
 
 // LibrariesAPI exposes the Library API
 type LibrariesAPI struct {
-	Client DBApiClient
+	Client *DBApiClient
 }
 
 // Create installs the list of libraries given a cluster id

--- a/client/service/notebooks.go
+++ b/client/service/notebooks.go
@@ -8,7 +8,7 @@ import (
 
 // NotebooksAPI exposes the Notebooks API
 type NotebooksAPI struct {
-	Client DBApiClient
+	Client *DBApiClient
 }
 
 // Create creates a notebook given the content and path

--- a/client/service/secret_acls.go
+++ b/client/service/secret_acls.go
@@ -8,7 +8,7 @@ import (
 
 // SecretAclsAPI exposes the Secret ACL API
 type SecretAclsAPI struct {
-	Client DBApiClient
+	Client *DBApiClient
 }
 
 // Create creates or overwrites the ACL associated with the given principal (user or group) on the specified scope point

--- a/client/service/secret_scopes.go
+++ b/client/service/secret_scopes.go
@@ -9,7 +9,7 @@ import (
 
 // SecretScopesAPI exposes the Secret Scopes API
 type SecretScopesAPI struct {
-	Client DBApiClient
+	Client *DBApiClient
 }
 
 // Create creates a new secret scope

--- a/client/service/secrets.go
+++ b/client/service/secrets.go
@@ -9,7 +9,7 @@ import (
 
 // SecretsAPI exposes the Secrets API
 type SecretsAPI struct {
-	Client DBApiClient
+	Client *DBApiClient
 }
 
 // Create creates or modifies a string secret depends on the type of scope backend

--- a/client/service/users.go
+++ b/client/service/users.go
@@ -14,7 +14,7 @@ import (
 
 // UsersAPI exposes the scim user API
 type UsersAPI struct {
-	Client DBApiClient
+	Client *DBApiClient
 }
 
 // Create given a username, displayname, entitlements, and roles will create a scim user via SCIM api

--- a/databricks/azure_auth_test.go
+++ b/databricks/azure_auth_test.go
@@ -22,10 +22,10 @@ func TestAzureAuthCreateApiToken(t *testing.T) {
 
 	azureAuth := AzureAuth{
 		TokenPayload: &TokenPayload{
-			ManagedResourceGroup: os.Getenv("TEST_MANAGED_RESOURCE_GROUP"),
-			AzureRegion:          "centralus",
-			WorkspaceName:        os.Getenv("TEST_WORKSPACE_NAME"),
-			ResourceGroup:        os.Getenv("TEST_RESOURCE_GROUP"),
+			ManagedResourceGroup: os.Getenv("DATABRICKS_AZURE_MANAGED_RESOURCE_GROUP"),
+			AzureRegion:          os.Getenv("AZURE_REGION"),
+			WorkspaceName:        os.Getenv("DATABRICKS_AZURE_WORKSPACE_NAME"),
+			ResourceGroup:        os.Getenv("DATABRICKS_AZURE_RESOURCE_GROUP"),
 		},
 		ManagementToken:        "",
 		AdbWorkspaceResourceID: "",
@@ -36,10 +36,11 @@ func TestAzureAuthCreateApiToken(t *testing.T) {
 	azureAuth.TokenPayload.TenantID = os.Getenv("DATABRICKS_AZURE_TENANT_ID")
 	azureAuth.TokenPayload.ClientID = os.Getenv("DATABRICKS_AZURE_CLIENT_ID")
 	azureAuth.TokenPayload.ClientSecret = os.Getenv("DATABRICKS_AZURE_CLIENT_SECRET")
-	option := GetIntegrationDBClientOptions()
-	api, err := azureAuth.initWorkspaceAndGetClient(option)
+	config := GetIntegrationDBClientOptions()
+	err := azureAuth.initWorkspaceAndGetClient(config)
 	assert.NoError(t, err, err)
-
+	api := service.DBApiClient{}
+	api.SetConfig(config)
 	instancePoolInfo, instancePoolErr := api.InstancePools().Create(model.InstancePool{
 		InstancePoolName:                   "my_instance_pool",
 		MinIdleInstances:                   0,

--- a/databricks/data_source_databricks_dbfs_file.go
+++ b/databricks/data_source_databricks_dbfs_file.go
@@ -35,7 +35,7 @@ func dataSourceDBFSFile() *schema.Resource {
 func dataSourceDBFSFileRead(d *schema.ResourceData, m interface{}) error {
 	path := d.Get("path").(string)
 	limitFileSize := d.Get("limit_file_size").(bool)
-	client := m.(service.DBApiClient)
+	client := m.(*service.DBApiClient)
 
 	fileInfo, err := client.DBFS().Status(path)
 	if err != nil {

--- a/databricks/data_source_databricks_dbfs_file_paths.go
+++ b/databricks/data_source_databricks_dbfs_file_paths.go
@@ -43,7 +43,7 @@ func dataSourceDBFSFilePaths() *schema.Resource {
 func dataSourceDBFSFilePathsRead(d *schema.ResourceData, m interface{}) error {
 	path := d.Get("path").(string)
 	recursive := d.Get("recursive").(bool)
-	client := m.(service.DBApiClient)
+	client := m.(*service.DBApiClient)
 
 	paths, err := client.DBFS().List(path, recursive)
 	if err != nil {

--- a/databricks/data_source_databricks_default_user_roles.go
+++ b/databricks/data_source_databricks_default_user_roles.go
@@ -8,7 +8,7 @@ import (
 func dataSourceDefaultUserRoles() *schema.Resource {
 	return &schema.Resource{
 		Read: func(d *schema.ResourceData, m interface{}) error {
-			client := m.(service.DBApiClient)
+			client := m.(*service.DBApiClient)
 
 			defaultRolesUserName := d.Get("default_username").(string)
 			metaUser, err := client.Users().GetOrCreateDefaultMetaUser(defaultRolesUserName, defaultRolesUserName, true)

--- a/databricks/data_source_databricks_notebook.go
+++ b/databricks/data_source_databricks_notebook.go
@@ -50,7 +50,7 @@ func dataSourceNotebook() *schema.Resource {
 func dataSourceNotebookRead(d *schema.ResourceData, m interface{}) error {
 	path := d.Get("path").(string)
 	format := d.Get("format").(string)
-	client := m.(service.DBApiClient)
+	client := m.(*service.DBApiClient)
 
 	notebookInfo, err := client.Notebooks().Read(path)
 	if err != nil {

--- a/databricks/data_source_databricks_notebook_paths.go
+++ b/databricks/data_source_databricks_notebook_paths.go
@@ -47,7 +47,7 @@ func dataSourceNotebookPathsRead(d *schema.ResourceData, m interface{}) error {
 	path := d.Get("path").(string)
 	recursive := d.Get("recursive").(bool)
 
-	client := m.(service.DBApiClient)
+	client := m.(*service.DBApiClient)
 
 	notebookList, err := client.Notebooks().List(path, recursive)
 	if err != nil {

--- a/databricks/data_source_databricks_zones.go
+++ b/databricks/data_source_databricks_zones.go
@@ -8,7 +8,7 @@ import (
 func dataSourceClusterZones() *schema.Resource {
 	return &schema.Resource{
 		Read: func(d *schema.ResourceData, m interface{}) error {
-			client := m.(service.DBApiClient)
+			client := m.(*service.DBApiClient)
 
 			zonesInfo, err := client.Clusters().ListZones()
 			if err != nil {

--- a/databricks/mounts.go
+++ b/databricks/mounts.go
@@ -11,9 +11,9 @@ import (
 
 // Mount interface describes the functionality of any mount which is create, read and delete
 type Mount interface {
-	Create(client service.DBApiClient, clusterID string) error
-	Delete(client service.DBApiClient, clusterID string) error
-	Read(client service.DBApiClient, clusterID string) (string, error)
+	Create(client *service.DBApiClient, clusterID string) error
+	Delete(client *service.DBApiClient, clusterID string) error
+	Read(client *service.DBApiClient, clusterID string) (string, error)
 }
 
 // AWSIamMount describes the object for a aws mount using iam role
@@ -29,7 +29,7 @@ func NewAWSIamMount(s3BucketName string, mountName string) *AWSIamMount {
 }
 
 // Create creates an aws iam mount given a cluster ID
-func (m AWSIamMount) Create(client service.DBApiClient, clusterID string) error {
+func (m AWSIamMount) Create(client *service.DBApiClient, clusterID string) error {
 	iamMountCommand := fmt.Sprintf(`
 dbutils.fs.mount("s3a://%s", "/mnt/%s")
 dbutils.fs.ls("/mnt/%s")
@@ -47,7 +47,7 @@ dbutils.notebook.exit("success")
 }
 
 // Delete deletes an aws iam mount given a cluster ID
-func (m AWSIamMount) Delete(client service.DBApiClient, clusterID string) error {
+func (m AWSIamMount) Delete(client *service.DBApiClient, clusterID string) error {
 	iamMountCommand := fmt.Sprintf(`
 dbutils.fs.unmount("/mnt/%s")
 dbutils.fs.refreshMounts()
@@ -65,7 +65,7 @@ dbutils.notebook.exit("success")
 }
 
 // Read verifies an aws iam mount given a cluster ID
-func (m AWSIamMount) Read(client service.DBApiClient, clusterID string) (string, error) {
+func (m AWSIamMount) Read(client *service.DBApiClient, clusterID string) (string, error) {
 	iamMountCommand := fmt.Sprintf(`
 dbutils.fs.ls("/mnt/%s")
 for mount in dbutils.fs.mounts():
@@ -108,7 +108,7 @@ func NewAzureBlobMount(containerName string, storageAccountName string, director
 }
 
 // Create creates a azure blob storage mount given a cluster id
-func (m AzureBlobMount) Create(client service.DBApiClient, clusterID string) error {
+func (m AzureBlobMount) Create(client *service.DBApiClient, clusterID string) error {
 	var confKey string
 
 	if m.AuthType == "SAS" {
@@ -139,7 +139,7 @@ dbutils.notebook.exit("success")
 }
 
 // Delete deletes a azure blob storage mount given a cluster id
-func (m AzureBlobMount) Delete(client service.DBApiClient, clusterID string) error {
+func (m AzureBlobMount) Delete(client *service.DBApiClient, clusterID string) error {
 	iamMountCommand := fmt.Sprintf(`
 dbutils.fs.unmount("/mnt/%s")
 dbutils.fs.refreshMounts()
@@ -157,7 +157,7 @@ dbutils.notebook.exit("success")
 }
 
 // Read verifies a azure blob storage mount given a cluster id
-func (m AzureBlobMount) Read(client service.DBApiClient, clusterID string) (string, error) {
+func (m AzureBlobMount) Read(client *service.DBApiClient, clusterID string) (string, error) {
 	iamMountCommand := fmt.Sprintf(`
 dbutils.fs.ls("/mnt/%s")
 for mount in dbutils.fs.mounts():
@@ -208,7 +208,7 @@ func NewAzureADLSGen1Mount(storageResource string, directory string, mountName s
 }
 
 // Create creates a azure datalake gen 1 storage mount given a cluster id
-func (m AzureADLSGen1Mount) Create(client service.DBApiClient, clusterID string) error {
+func (m AzureADLSGen1Mount) Create(client *service.DBApiClient, clusterID string) error {
 	iamMountCommand := fmt.Sprintf(`
 try:
   configs = {"%s.oauth2.access.token.provider.type": "ClientCredential",
@@ -237,7 +237,7 @@ dbutils.notebook.exit("success")
 }
 
 // Delete deletes a azure datalake gen 1 storage mount given a cluster id
-func (m AzureADLSGen1Mount) Delete(client service.DBApiClient, clusterID string) error {
+func (m AzureADLSGen1Mount) Delete(client *service.DBApiClient, clusterID string) error {
 	iamMountCommand := fmt.Sprintf(`
 dbutils.fs.unmount("/mnt/%s")
 dbutils.fs.refreshMounts()
@@ -255,7 +255,7 @@ dbutils.notebook.exit("success")
 }
 
 // Read verifies the azure datalake gen 1 storage mount given a cluster id
-func (m AzureADLSGen1Mount) Read(client service.DBApiClient, clusterID string) (string, error) {
+func (m AzureADLSGen1Mount) Read(client *service.DBApiClient, clusterID string) (string, error) {
 	iamMountCommand := fmt.Sprintf(`
 dbutils.fs.ls("/mnt/%s")
 for mount in dbutils.fs.mounts():
@@ -306,7 +306,7 @@ func NewAzureADLSGen2Mount(containerName string, storageAccountName string, dire
 }
 
 // Create creates a azure datalake gen 2 storage mount
-func (m AzureADLSGen2Mount) Create(client service.DBApiClient, clusterID string) error {
+func (m AzureADLSGen2Mount) Create(client *service.DBApiClient, clusterID string) error {
 	iamMountCommand := fmt.Sprintf(`
 try:
   configs = {"fs.azure.account.auth.type": "OAuth",
@@ -339,7 +339,7 @@ dbutils.notebook.exit("success")
 }
 
 // Delete deletes a azure datalake gen 2 storage mount
-func (m AzureADLSGen2Mount) Delete(client service.DBApiClient, clusterID string) error {
+func (m AzureADLSGen2Mount) Delete(client *service.DBApiClient, clusterID string) error {
 	iamMountCommand := fmt.Sprintf(`
 dbutils.fs.unmount("/mnt/%s")
 dbutils.fs.refreshMounts()
@@ -357,7 +357,7 @@ dbutils.notebook.exit("success")
 }
 
 // Read verifies the azure datalake gen 2 storage mount
-func (m AzureADLSGen2Mount) Read(client service.DBApiClient, clusterID string) (string, error) {
+func (m AzureADLSGen2Mount) Read(client *service.DBApiClient, clusterID string) (string, error) {
 	iamMountCommand := fmt.Sprintf(`
 dbutils.fs.ls("/mnt/%s")
 for mount in dbutils.fs.mounts():

--- a/databricks/provider.go
+++ b/databricks/provider.go
@@ -187,8 +187,14 @@ func providerConfigureAzureClient(d *schema.ResourceData, providerVersion string
 		AdbAccessToken:         "",
 		AdbPlatformToken:       "",
 	}
-	log.Println("Running Azure Auth")
-	return azureAuthSetup.initWorkspaceAndGetClient(config)
+
+	// Setup the CustomAuthorizer Function to be called at API invoke rather than client invoke
+	config.CustomAuthorizer = func(config *service.DBApiClientConfig) error {
+		return azureAuthSetup.initWorkspaceAndGetClient(config)
+	}
+	var dbClient service.DBApiClient
+	dbClient.SetConfig(config)
+	return &dbClient, nil
 }
 
 func providerConfigure(d *schema.ResourceData, providerVersion string) (interface{}, error) {
@@ -214,5 +220,5 @@ func providerConfigure(d *schema.ResourceData, providerVersion string) (interfac
 	config.UserAgent = fmt.Sprintf("databricks-tf-provider-%s", providerVersion)
 	var dbClient service.DBApiClient
 	dbClient.SetConfig(&config)
-	return dbClient, nil
+	return &dbClient, nil
 }

--- a/databricks/provider_test.go
+++ b/databricks/provider_test.go
@@ -2,6 +2,7 @@ package databricks
 
 import (
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"log"
 	"os"
 	"testing"
@@ -42,4 +43,36 @@ func TestMain(m *testing.M) {
 	}
 	code := m.Run()
 	os.Exit(code)
+}
+
+func TestAccProviderConfigureAzureSPAuth(t *testing.T) {
+	resource.Test(t,
+		resource.TestCase{
+			Providers: testAccProviders,
+			Steps: []resource.TestStep{
+				{
+					PlanOnly:           true,
+					Config:             testInitialEmptyWorkspaceClusterDeployment(),
+					ExpectNonEmptyPlan: true,
+				},
+			},
+		},
+	)
+}
+
+func testInitialEmptyWorkspaceClusterDeployment() string {
+	return `
+provider "databricks" {
+  azure_auth = {
+    managed_resource_group = "azurerm_databricks_workspace.demo.managed_resource_group_name"
+    azure_region           = "westus"
+    workspace_name         = "azurerm_databricks_workspace.demo.name"
+    resource_group         = "azurerm_databricks_workspace.demo.resource_group_name"
+  }
+}
+
+resource "databricks_scim_group" "my-group-azure3" {
+  display_name = "Test terraform Group3"
+}
+`
 }

--- a/databricks/resource_databricks_aws_s3_mount.go
+++ b/databricks/resource_databricks_aws_s3_mount.go
@@ -32,7 +32,7 @@ func resourceAWSS3Mount() *schema.Resource {
 }
 
 func resourceAWSS3Create(d *schema.ResourceData, m interface{}) error {
-	client := m.(service.DBApiClient)
+	client := m.(*service.DBApiClient)
 	clusterID := d.Get("cluster_id").(string)
 	err := changeClusterIntoRunningState(clusterID, client)
 	if err != nil {
@@ -63,7 +63,7 @@ func resourceAWSS3Create(d *schema.ResourceData, m interface{}) error {
 }
 
 func resourceAWSS3Read(d *schema.ResourceData, m interface{}) error {
-	client := m.(service.DBApiClient)
+	client := m.(*service.DBApiClient)
 	clusterID := d.Get("cluster_id").(string)
 	err := changeClusterIntoRunningState(clusterID, client)
 	if err != nil {
@@ -84,7 +84,7 @@ func resourceAWSS3Read(d *schema.ResourceData, m interface{}) error {
 }
 
 func resourceAWSS3Delete(d *schema.ResourceData, m interface{}) error {
-	client := m.(service.DBApiClient)
+	client := m.(*service.DBApiClient)
 	clusterID := d.Get("cluster_id").(string)
 	err := changeClusterIntoRunningState(clusterID, client)
 	if err != nil {

--- a/databricks/resource_databricks_azure_adls_gen1_mount.go
+++ b/databricks/resource_databricks_azure_adls_gen1_mount.go
@@ -77,7 +77,7 @@ func resourceAzureAdlsGen1Mount() *schema.Resource {
 }
 
 func resourceAzureAdlsGen1Create(d *schema.ResourceData, m interface{}) error {
-	client := m.(service.DBApiClient)
+	client := m.(*service.DBApiClient)
 	clusterID := d.Get("cluster_id").(string)
 	err := changeClusterIntoRunningState(clusterID, client)
 	if err != nil {
@@ -133,7 +133,7 @@ func resourceAzureAdlsGen1Create(d *schema.ResourceData, m interface{}) error {
 	return resourceAzureAdlsGen1Read(d, m)
 }
 func resourceAzureAdlsGen1Read(d *schema.ResourceData, m interface{}) error {
-	client := m.(service.DBApiClient)
+	client := m.(*service.DBApiClient)
 	clusterID := d.Get("cluster_id").(string)
 	err := changeClusterIntoRunningState(clusterID, client)
 	if err != nil {
@@ -174,7 +174,7 @@ func resourceAzureAdlsGen1Read(d *schema.ResourceData, m interface{}) error {
 }
 
 func resourceAzureAdlsGen1Delete(d *schema.ResourceData, m interface{}) error {
-	client := m.(service.DBApiClient)
+	client := m.(*service.DBApiClient)
 	clusterID := d.Get("cluster_id").(string)
 	err := changeClusterIntoRunningState(clusterID, client)
 	if err != nil {

--- a/databricks/resource_databricks_azure_adls_gen2_mount.go
+++ b/databricks/resource_databricks_azure_adls_gen2_mount.go
@@ -70,7 +70,7 @@ func resourceAzureAdlsGen2Mount() *schema.Resource {
 }
 
 func resourceAzureAdlsGen2Create(d *schema.ResourceData, m interface{}) error {
-	client := m.(service.DBApiClient)
+	client := m.(*service.DBApiClient)
 	clusterID := d.Get("cluster_id").(string)
 	err := changeClusterIntoRunningState(clusterID, client)
 	if err != nil {
@@ -127,7 +127,7 @@ func resourceAzureAdlsGen2Create(d *schema.ResourceData, m interface{}) error {
 	return resourceAzureAdlsGen2Read(d, m)
 }
 func resourceAzureAdlsGen2Read(d *schema.ResourceData, m interface{}) error {
-	client := m.(service.DBApiClient)
+	client := m.(*service.DBApiClient)
 	clusterID := d.Get("cluster_id").(string)
 	err := changeClusterIntoRunningState(clusterID, client)
 	if err != nil {
@@ -173,7 +173,7 @@ func resourceAzureAdlsGen2Read(d *schema.ResourceData, m interface{}) error {
 }
 
 func resourceAzureAdlsGen2Delete(d *schema.ResourceData, m interface{}) error {
-	client := m.(service.DBApiClient)
+	client := m.(*service.DBApiClient)
 	clusterID := d.Get("cluster_id").(string)
 	err := changeClusterIntoRunningState(clusterID, client)
 	if err != nil {

--- a/databricks/resource_databricks_azure_blob_mount.go
+++ b/databricks/resource_databricks_azure_blob_mount.go
@@ -71,7 +71,7 @@ func resourceAzureBlobMount() *schema.Resource {
 }
 
 func resourceAzureBlobMountCreate(d *schema.ResourceData, m interface{}) error {
-	client := m.(service.DBApiClient)
+	client := m.(*service.DBApiClient)
 	clusterID := d.Get("cluster_id").(string)
 	err := changeClusterIntoRunningState(clusterID, client)
 	if err != nil {
@@ -119,7 +119,7 @@ func resourceAzureBlobMountCreate(d *schema.ResourceData, m interface{}) error {
 	return resourceAzureBlobMountRead(d, m)
 }
 func resourceAzureBlobMountRead(d *schema.ResourceData, m interface{}) error {
-	client := m.(service.DBApiClient)
+	client := m.(*service.DBApiClient)
 	clusterID := d.Get("cluster_id").(string)
 	err := changeClusterIntoRunningState(clusterID, client)
 	if err != nil {
@@ -163,7 +163,7 @@ func resourceAzureBlobMountRead(d *schema.ResourceData, m interface{}) error {
 }
 
 func resourceAzureBlobMountDelete(d *schema.ResourceData, m interface{}) error {
-	client := m.(service.DBApiClient)
+	client := m.(*service.DBApiClient)
 	clusterID := d.Get("cluster_id").(string)
 	err := changeClusterIntoRunningState(clusterID, client)
 	if err != nil {

--- a/databricks/resource_databricks_azure_blob_mount_test.go
+++ b/databricks/resource_databricks_azure_blob_mount_test.go
@@ -29,7 +29,7 @@ func TestAccAzureBlobMount_correctly_mounts(t *testing.T) {
 			},
 			{
 				PreConfig: func() {
-					client := testAccProvider.Meta().(service.DBApiClient)
+					client := testAccProvider.Meta().(*service.DBApiClient)
 					err := azureBlobMount.Delete(client, clusterInfo.ClusterID)
 					assert.NoError(t, err, "TestAccAzureBlobMount_correctly_mounts: Failed to remove the mount.")
 				},
@@ -51,7 +51,7 @@ func testAccAzureBlobMount_cluster_exists(n string, clusterInfo *model.ClusterIn
 		}
 
 		// retrieve the configured client from the test setup
-		client := testAccProvider.Meta().(service.DBApiClient)
+		client := testAccProvider.Meta().(*service.DBApiClient)
 		resp, err := client.Clusters().Get(rs.Primary.ID)
 		if err != nil {
 			return err
@@ -82,7 +82,7 @@ func testAccAzureBlobMount_mount_exists(n string, azureBlobMount *AzureBlobMount
 		blobMount := NewAzureBlobMount(containerName, storageAccountName, directory, mountName, authType,
 			tokenSecretScope, tokenSecretKey)
 
-		client := testAccProvider.Meta().(service.DBApiClient)
+		client := testAccProvider.Meta().(*service.DBApiClient)
 		cluster_id := clusterInfo.ClusterID
 
 		message, err := blobMount.Read(client, cluster_id)

--- a/databricks/resource_databricks_cluster.go
+++ b/databricks/resource_databricks_cluster.go
@@ -501,7 +501,7 @@ func convertListInterfaceToString(m []interface{}) []string {
 
 func resourceClusterCreate(d *schema.ResourceData, m interface{}) error {
 
-	client := m.(service.DBApiClient)
+	client := m.(*service.DBApiClient)
 
 	cluster := parseSchemaToCluster(d, "")
 	libraries := parseSchemaToClusterLibraries(d)
@@ -536,7 +536,7 @@ func resourceClusterCreate(d *schema.ResourceData, m interface{}) error {
 }
 
 func resourceClusterRead(d *schema.ResourceData, m interface{}) error {
-	client := m.(service.DBApiClient)
+	client := m.(*service.DBApiClient)
 	id := d.Id()
 
 	clusterInfo, err := client.Clusters().Get(id)
@@ -1039,7 +1039,7 @@ func parseSchemaToClusterLibraries(d *schema.ResourceData) []model.Library {
 }
 
 func resourceClusterUpdate(d *schema.ResourceData, m interface{}) error {
-	client := m.(service.DBApiClient)
+	client := m.(*service.DBApiClient)
 	id := d.Id()
 	clusterInfo, err := client.Clusters().Get(id)
 	if err != nil {
@@ -1161,7 +1161,7 @@ func resourceClusterUpdate(d *schema.ResourceData, m interface{}) error {
 
 func resourceClusterDelete(d *schema.ResourceData, m interface{}) error {
 	id := d.Id()
-	client := m.(service.DBApiClient)
+	client := m.(*service.DBApiClient)
 
 	err := client.Clusters().PermanentDelete(id)
 	if err != nil {

--- a/databricks/resource_databricks_dbfs_file.go
+++ b/databricks/resource_databricks_dbfs_file.go
@@ -50,7 +50,7 @@ func resourceDBFSFile() *schema.Resource {
 }
 
 func resourceDBFSFileCreate(d *schema.ResourceData, m interface{}) error {
-	client := m.(service.DBApiClient)
+	client := m.(*service.DBApiClient)
 	path := d.Get("path").(string)
 	content := d.Get("content").(string)
 	overwrite := d.Get("overwrite").(bool)
@@ -88,7 +88,7 @@ func resourceDBFSFileCreate(d *schema.ResourceData, m interface{}) error {
 
 func resourceDBFSFileRead(d *schema.ResourceData, m interface{}) error {
 	id := d.Id()
-	client := m.(service.DBApiClient)
+	client := m.(*service.DBApiClient)
 
 	fileInfo, err := client.DBFS().Status(id)
 	if err != nil {
@@ -139,7 +139,7 @@ func resourceDBFSFileUpdate(d *schema.ResourceData, m interface{}) error {
 }
 func resourceDBFSFileDelete(d *schema.ResourceData, m interface{}) error {
 	id := d.Id()
-	client := m.(service.DBApiClient)
+	client := m.(*service.DBApiClient)
 	err := client.DBFS().Delete(id, false)
 	return err
 }

--- a/databricks/resource_databricks_dbfs_file_sync.go
+++ b/databricks/resource_databricks_dbfs_file_sync.go
@@ -49,7 +49,7 @@ func resourceDBFSFileSync() *schema.Resource {
 }
 
 func resourceDBFSFileSyncCreate(d *schema.ResourceData, m interface{}) error {
-	client := m.(service.DBApiClient)
+	client := m.(*service.DBApiClient)
 	srcPath := d.Get("src_path").(string)
 	tgtPath := d.Get("tgt_path").(string)
 	mkdirs := d.Get("mkdirs").(bool)
@@ -62,7 +62,7 @@ func resourceDBFSFileSyncCreate(d *schema.ResourceData, m interface{}) error {
 		}
 	}
 
-	apiClient := parseSchemaToDBAPIClient(d, &client)
+	apiClient := parseSchemaToDBAPIClient(d, client)
 	err := client.DBFS().Copy(srcPath, tgtPath, apiClient, true)
 	if err != nil {
 		return err
@@ -96,12 +96,12 @@ func resourceDBFSFileSyncUpdate(d *schema.ResourceData, m interface{}) error {
 }
 
 func resourceDBFSFileSyncRead(d *schema.ResourceData, m interface{}) error {
-	client := m.(service.DBApiClient)
+	client := m.(*service.DBApiClient)
 	srcPath := d.Get("src_path").(string)
 	tgtPath := d.Get("tgt_path").(string)
 
 	var srcAPIDBFSClient service.DBFSAPI
-	srcAPICLient := parseSchemaToDBAPIClient(d, &client)
+	srcAPICLient := parseSchemaToDBAPIClient(d, client)
 	if srcAPICLient != nil {
 		srcAPIDBFSClient = srcAPICLient.DBFS()
 	} else {
@@ -125,7 +125,7 @@ func resourceDBFSFileSyncRead(d *schema.ResourceData, m interface{}) error {
 }
 
 func resourceDBFSFileSyncDelete(d *schema.ResourceData, m interface{}) error {
-	client := m.(service.DBApiClient)
+	client := m.(*service.DBApiClient)
 	id := strings.Split(d.Id(), "|||")[1]
 
 	err := client.DBFS().Delete(id, false)

--- a/databricks/resource_databricks_instance_pool.go
+++ b/databricks/resource_databricks_instance_pool.go
@@ -160,7 +160,7 @@ func convertMapStringInterfaceToStringString(m map[string]interface{}) map[strin
 }
 
 func resourceInstancePoolCreate(d *schema.ResourceData, m interface{}) error {
-	client := m.(service.DBApiClient)
+	client := m.(*service.DBApiClient)
 
 	var instancePool model.InstancePool
 	var instancePoolAwsAttributes model.InstancePoolAwsAttributes
@@ -235,7 +235,7 @@ func resourceInstancePoolCreate(d *schema.ResourceData, m interface{}) error {
 
 func resourceInstancePoolRead(d *schema.ResourceData, m interface{}) error {
 	id := d.Id()
-	client := m.(service.DBApiClient)
+	client := m.(*service.DBApiClient)
 	instancePoolInfo, err := client.InstancePools().Read(id)
 	if err != nil {
 		if isInstancePoolMissing(err.Error(), id) {
@@ -334,7 +334,7 @@ func resourceInstancePoolRead(d *schema.ResourceData, m interface{}) error {
 
 func resourceInstancePoolUpdate(d *schema.ResourceData, m interface{}) error {
 	id := d.Id()
-	client := m.(service.DBApiClient)
+	client := m.(*service.DBApiClient)
 
 	var instancePoolInfo model.InstancePoolInfo
 	instancePoolInfo.InstancePoolName = d.Get("instance_pool_name").(string)
@@ -352,7 +352,7 @@ func resourceInstancePoolUpdate(d *schema.ResourceData, m interface{}) error {
 }
 
 func resourceInstancePoolDelete(d *schema.ResourceData, m interface{}) error {
-	client := m.(service.DBApiClient)
+	client := m.(*service.DBApiClient)
 	id := d.Id()
 	err := client.InstancePools().Delete(id)
 	return err

--- a/databricks/resource_databricks_instance_profile.go
+++ b/databricks/resource_databricks_instance_profile.go
@@ -30,7 +30,7 @@ func resourceInstanceProfile() *schema.Resource {
 }
 
 func resourceInstanceProfileCreate(d *schema.ResourceData, m interface{}) error {
-	client := m.(service.DBApiClient)
+	client := m.(*service.DBApiClient)
 	instanceProfileArn := d.Get("instance_profile_arn").(string)
 	skipValidation := d.Get("skip_validation").(bool)
 	err := client.InstanceProfiles().Create(instanceProfileArn, skipValidation)
@@ -48,7 +48,7 @@ func resourceInstanceProfileCreate(d *schema.ResourceData, m interface{}) error 
 
 func resourceInstanceProfileRead(d *schema.ResourceData, m interface{}) error {
 	id := d.Id()
-	client := m.(service.DBApiClient)
+	client := m.(*service.DBApiClient)
 	profile, err := client.InstanceProfiles().Read(id)
 	if err != nil {
 		if isInstanceProfileMissing(err.Error(), id) {
@@ -64,7 +64,7 @@ func resourceInstanceProfileRead(d *schema.ResourceData, m interface{}) error {
 
 func resourceInstanceProfileDelete(d *schema.ResourceData, m interface{}) error {
 	id := d.Id()
-	client := m.(service.DBApiClient)
+	client := m.(*service.DBApiClient)
 	err := client.InstanceProfiles().Delete(id)
 	return err
 }

--- a/databricks/resource_databricks_job.go
+++ b/databricks/resource_databricks_job.go
@@ -513,7 +513,7 @@ func resourceJob() *schema.Resource {
 
 func resourceJobCreate(d *schema.ResourceData, m interface{}) error {
 
-	client := m.(service.DBApiClient)
+	client := m.(*service.DBApiClient)
 
 	jobSettings := parseSchemaToJobSettings(d)
 	job, err := client.Jobs().Create(jobSettings)
@@ -526,7 +526,7 @@ func resourceJobCreate(d *schema.ResourceData, m interface{}) error {
 }
 
 func resourceJobRead(d *schema.ResourceData, m interface{}) error {
-	client := m.(service.DBApiClient)
+	client := m.(*service.DBApiClient)
 	id := d.Id()
 	idInt, err := strconv.ParseInt(id, 10, 32)
 	if err != nil {
@@ -947,7 +947,7 @@ func resourceJobRead(d *schema.ResourceData, m interface{}) error {
 }
 
 func resourceJobUpdate(d *schema.ResourceData, m interface{}) error {
-	client := m.(service.DBApiClient)
+	client := m.(*service.DBApiClient)
 	id := d.Id()
 	idInt, err := strconv.ParseInt(id, 10, 32)
 	if err != nil {
@@ -963,7 +963,7 @@ func resourceJobUpdate(d *schema.ResourceData, m interface{}) error {
 }
 
 func resourceJobDelete(d *schema.ResourceData, m interface{}) error {
-	client := m.(service.DBApiClient)
+	client := m.(*service.DBApiClient)
 	id := d.Id()
 	idInt, err := strconv.ParseInt(id, 10, 32)
 	if err != nil {

--- a/databricks/resource_databricks_notebook.go
+++ b/databricks/resource_databricks_notebook.go
@@ -94,7 +94,7 @@ func resourceNotebook() *schema.Resource {
 }
 
 func resourceNotebookCreate(d *schema.ResourceData, m interface{}) error {
-	client := m.(service.DBApiClient)
+	client := m.(*service.DBApiClient)
 	path := d.Get("path").(string)
 	content := d.Get("content").(string)
 	language := d.Get("language").(string)
@@ -136,7 +136,7 @@ func resourceNotebookCreate(d *schema.ResourceData, m interface{}) error {
 
 func resourceNotebookRead(d *schema.ResourceData, m interface{}) error {
 	id := d.Id()
-	client := m.(service.DBApiClient)
+	client := m.(*service.DBApiClient)
 	format := d.Get("format").(string)
 	notebookData, err := client.Notebooks().Export(id, model.ExportFormat(format))
 	if err != nil {
@@ -179,7 +179,7 @@ func resourceNotebookRead(d *schema.ResourceData, m interface{}) error {
 
 func resourceNotebookDelete(d *schema.ResourceData, m interface{}) error {
 	id := d.Id()
-	client := m.(service.DBApiClient)
+	client := m.(*service.DBApiClient)
 	err := client.Notebooks().Delete(id, true)
 	return err
 }

--- a/databricks/resource_databricks_scim_group.go
+++ b/databricks/resource_databricks_scim_group.go
@@ -74,7 +74,7 @@ func resourceScimGroup() *schema.Resource {
 //}
 
 func resourceScimGroupCreate(d *schema.ResourceData, m interface{}) error {
-	client := m.(service.DBApiClient)
+	client := m.(*service.DBApiClient)
 	groupName := d.Get("display_name").(string)
 	var members []string
 
@@ -121,7 +121,7 @@ func getListOfEntitlements(entitlementList []model.EntitlementsListItem) []strin
 
 func resourceScimGroupRead(d *schema.ResourceData, m interface{}) error {
 	id := d.Id()
-	client := m.(service.DBApiClient)
+	client := m.(*service.DBApiClient)
 	group, err := client.Groups().Read(id)
 	if err != nil {
 		if isScimGroupMissing(err.Error(), id) {
@@ -177,7 +177,7 @@ func diff(sliceA []string, sliceB []string) []string {
 
 func resourceScimGroupUpdate(d *schema.ResourceData, m interface{}) error {
 	id := d.Id()
-	client := m.(service.DBApiClient)
+	client := m.(*service.DBApiClient)
 
 	group, err := client.Groups().Read(id)
 	if err != nil {
@@ -243,7 +243,7 @@ func resourceScimGroupUpdate(d *schema.ResourceData, m interface{}) error {
 
 func resourceScimGroupDelete(d *schema.ResourceData, m interface{}) error {
 	id := d.Id()
-	client := m.(service.DBApiClient)
+	client := m.(*service.DBApiClient)
 	err := client.Groups().Delete(id)
 	return err
 }

--- a/databricks/resource_databricks_scim_group_aws_test.go
+++ b/databricks/resource_databricks_scim_group_aws_test.go
@@ -89,7 +89,7 @@ func TestAccScimGroupResource(t *testing.T) {
 			},
 			{
 				PreConfig: func() {
-					err := testAccProvider.Meta().(service.DBApiClient).Groups().Delete(ScimGroup.ID)
+					err := testAccProvider.Meta().(*service.DBApiClient).Groups().Delete(ScimGroup.ID)
 					assert.NoError(t, err, err)
 				},
 				// use a dynamic configuration with the random name from above
@@ -131,7 +131,7 @@ func TestAccScimGroupResource(t *testing.T) {
 }
 
 func testScimGroupResourceDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(service.DBApiClient)
+	client := testAccProvider.Meta().(*service.DBApiClient)
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "databricks_scim_group" {
 			continue
@@ -165,7 +165,7 @@ func testScimGroupResourceExists(n string, group *model.Group, t *testing.T) res
 		}
 
 		// retrieve the configured client from the test setup
-		conn := testAccProvider.Meta().(service.DBApiClient)
+		conn := testAccProvider.Meta().(*service.DBApiClient)
 		resp, err := conn.Groups().Read(rs.Primary.ID)
 		if err != nil {
 			return err

--- a/databricks/resource_databricks_scim_group_azure_test.go
+++ b/databricks/resource_databricks_scim_group_azure_test.go
@@ -83,7 +83,7 @@ func TestAccScimGroupResource(t *testing.T) {
 			},
 			{
 				PreConfig: func() {
-					err := testAccProvider.Meta().(service.DBApiClient).Groups().Delete(ScimGroup.ID)
+					err := testAccProvider.Meta().(*service.DBApiClient).Groups().Delete(ScimGroup.ID)
 					assert.NoError(t, err, err)
 				},
 				// use a dynamic configuration with the random name from above
@@ -122,7 +122,7 @@ func TestAccScimGroupResource(t *testing.T) {
 }
 
 func testScimGroupResourceDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(service.DBApiClient)
+	client := testAccProvider.Meta().(*service.DBApiClient)
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "databricks_scim_group" {
 			continue
@@ -155,7 +155,7 @@ func testScimGroupResourceExists(n string, group *model.Group, t *testing.T) res
 		}
 
 		// retrieve the configured client from the test setup
-		conn := testAccProvider.Meta().(service.DBApiClient)
+		conn := testAccProvider.Meta().(*service.DBApiClient)
 		resp, err := conn.Groups().Read(rs.Primary.ID)
 		if err != nil {
 			return err

--- a/databricks/resource_databricks_scim_user.go
+++ b/databricks/resource_databricks_scim_user.go
@@ -73,7 +73,7 @@ func convertInterfaceSliceToStringSlice(input []interface{}) []string {
 }
 
 func resourceScimUserCreate(d *schema.ResourceData, m interface{}) error {
-	client := m.(service.DBApiClient)
+	client := m.(*service.DBApiClient)
 	userName := d.Get("user_name").(string)
 	setAdmin := d.Get("set_admin").(bool)
 	var displayName string
@@ -127,7 +127,7 @@ func getListOfRoles(roleList []model.RoleListItem) []string {
 
 func resourceScimUserRead(d *schema.ResourceData, m interface{}) error {
 	id := d.Id()
-	client := m.(service.DBApiClient)
+	client := m.(*service.DBApiClient)
 	user, err := client.Users().Read(id)
 	if err != nil {
 		if isScimUserMissing(err.Error(), id) {
@@ -200,7 +200,7 @@ func resourceScimUserRead(d *schema.ResourceData, m interface{}) error {
 
 func resourceScimUserUpdate(d *schema.ResourceData, m interface{}) error {
 	id := d.Id()
-	client := m.(service.DBApiClient)
+	client := m.(*service.DBApiClient)
 	userName := d.Get("user_name").(string)
 	var displayName string
 	var roles []string
@@ -246,7 +246,7 @@ func resourceScimUserUpdate(d *schema.ResourceData, m interface{}) error {
 
 func resourceScimUserDelete(d *schema.ResourceData, m interface{}) error {
 	id := d.Id()
-	client := m.(service.DBApiClient)
+	client := m.(*service.DBApiClient)
 	err := client.Users().Delete(id)
 	return err
 }

--- a/databricks/resource_databricks_scim_user_aws_test.go
+++ b/databricks/resource_databricks_scim_user_aws_test.go
@@ -83,7 +83,7 @@ func TestAccScimUserResource(t *testing.T) {
 			},
 			{
 				PreConfig: func() {
-					err := testAccProvider.Meta().(service.DBApiClient).Users().Delete(scimUser.ID)
+					err := testAccProvider.Meta().(*service.DBApiClient).Users().Delete(scimUser.ID)
 					assert.NoError(t, err, err)
 				},
 				// use a dynamic configuration with the random name from above
@@ -104,7 +104,7 @@ func TestAccScimUserResource(t *testing.T) {
 			{
 				//Create a new user
 				PreConfig: func() {
-					err := testAccProvider.Meta().(service.DBApiClient).Users().Delete(scimUser.ID)
+					err := testAccProvider.Meta().(*service.DBApiClient).Users().Delete(scimUser.ID)
 					assert.NoError(t, err, err)
 				},
 				// Create new admin user
@@ -162,7 +162,7 @@ func TestAccScimUserResource(t *testing.T) {
 }
 
 func testScimUserResourceDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(service.DBApiClient)
+	client := testAccProvider.Meta().(*service.DBApiClient)
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "databricks_scim_user" {
 			continue
@@ -195,7 +195,7 @@ func testScimUserResourceExists(n string, user *model.User, t *testing.T) resour
 		}
 
 		// retrieve the configured client from the test setup
-		conn := testAccProvider.Meta().(service.DBApiClient)
+		conn := testAccProvider.Meta().(*service.DBApiClient)
 		resp, err := conn.Users().Read(rs.Primary.ID)
 		if err != nil {
 			return err

--- a/databricks/resource_databricks_scim_user_azure_test.go
+++ b/databricks/resource_databricks_scim_user_azure_test.go
@@ -85,7 +85,7 @@ func TestAccScimUserResource(t *testing.T) {
 			},
 			{
 				PreConfig: func() {
-					err := testAccProvider.Meta().(service.DBApiClient).Users().Delete(scimUser.ID)
+					err := testAccProvider.Meta().(*service.DBApiClient).Users().Delete(scimUser.ID)
 					assert.NoError(t, err, err)
 				},
 				// use a dynamic configuration with the random name from above
@@ -106,7 +106,7 @@ func TestAccScimUserResource(t *testing.T) {
 			{
 				//Create a new user
 				PreConfig: func() {
-					err := testAccProvider.Meta().(service.DBApiClient).Users().Delete(scimUser.ID)
+					err := testAccProvider.Meta().(*service.DBApiClient).Users().Delete(scimUser.ID)
 					assert.NoError(t, err, err)
 				},
 				// Create new admin user
@@ -164,7 +164,7 @@ func TestAccScimUserResource(t *testing.T) {
 }
 
 func testScimUserResourceDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(service.DBApiClient)
+	client := testAccProvider.Meta().(*service.DBApiClient)
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "databricks_scim_user" {
 			continue
@@ -215,7 +215,7 @@ func testScimUserResourceExists(n string, user *model.User, t *testing.T) resour
 		}
 
 		// retrieve the configured client from the test setup
-		conn := testAccProvider.Meta().(service.DBApiClient)
+		conn := testAccProvider.Meta().(*service.DBApiClient)
 		resp, err := conn.Users().Read(rs.Primary.ID)
 		if err != nil {
 			return err

--- a/databricks/resource_databricks_secret.go
+++ b/databricks/resource_databricks_secret.go
@@ -49,7 +49,7 @@ func getScopeAndKeyFromSecretID(secretIDString string) (string, string, error) {
 }
 
 func resourceSecretCreate(d *schema.ResourceData, m interface{}) error {
-	client := m.(service.DBApiClient)
+	client := m.(*service.DBApiClient)
 	scopeName := d.Get("scope").(string)
 	key := d.Get("key").(string)
 	secretValue := d.Get("string_value").(string)
@@ -67,7 +67,7 @@ func resourceSecretCreate(d *schema.ResourceData, m interface{}) error {
 
 func resourceSecretRead(d *schema.ResourceData, m interface{}) error {
 	id := d.Id()
-	client := m.(service.DBApiClient)
+	client := m.(*service.DBApiClient)
 	scope, key, err := getScopeAndKeyFromSecretID(id)
 	if err != nil {
 		return err
@@ -99,7 +99,7 @@ func resourceSecretRead(d *schema.ResourceData, m interface{}) error {
 }
 
 func resourceSecretDelete(d *schema.ResourceData, m interface{}) error {
-	client := m.(service.DBApiClient)
+	client := m.(*service.DBApiClient)
 	id := d.Id()
 	scope, key, err := getScopeAndKeyFromSecretID(id)
 	if err != nil {

--- a/databricks/resource_databricks_secret_acl.go
+++ b/databricks/resource_databricks_secret_acl.go
@@ -44,7 +44,7 @@ func getScopeAndKeyFromSecretACLID(SecretACLIDString string) (string, string, er
 }
 
 func resourceSecretACLCreate(d *schema.ResourceData, m interface{}) error {
-	client := m.(service.DBApiClient)
+	client := m.(*service.DBApiClient)
 	scopeName := d.Get("scope").(string)
 	principal := d.Get("principal").(string)
 	permission := model.ACLPermission(d.Get("permission").(string))
@@ -66,7 +66,7 @@ func resourceSecretACLRead(d *schema.ResourceData, m interface{}) error {
 	if err != nil {
 		return err
 	}
-	client := m.(service.DBApiClient)
+	client := m.(*service.DBApiClient)
 	secretACL, err := client.SecretAcls().Read(scope, principal)
 	if err != nil {
 		if isSecretACLMissing(err.Error(), scope, principal) {
@@ -89,7 +89,7 @@ func resourceSecretACLRead(d *schema.ResourceData, m interface{}) error {
 }
 
 func resourceSecretACLDelete(d *schema.ResourceData, m interface{}) error {
-	client := m.(service.DBApiClient)
+	client := m.(*service.DBApiClient)
 	id := d.Id()
 	scope, key, err := getScopeAndKeyFromSecretACLID(id)
 	if err != nil {

--- a/databricks/resource_databricks_secret_acl_test.go
+++ b/databricks/resource_databricks_secret_acl_test.go
@@ -45,7 +45,7 @@ func TestAccSecretAclResource(t *testing.T) {
 			},
 			{
 				PreConfig: func() {
-					client := testAccProvider.Meta().(service.DBApiClient)
+					client := testAccProvider.Meta().(*service.DBApiClient)
 					err := client.SecretAcls().Delete(scope, principal)
 					assert.NoError(t, err, err)
 				},
@@ -68,7 +68,7 @@ func TestAccSecretAclResource(t *testing.T) {
 }
 
 func testSecretACLResourceDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(service.DBApiClient)
+	client := testAccProvider.Meta().(*service.DBApiClient)
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "databricks_secret" && rs.Type != "databricks_secret_scope" {
 			continue
@@ -103,7 +103,7 @@ func testSecretACLResourceExists(n string, aclItem *model.ACLItem, t *testing.T)
 		}
 
 		// retrieve the configured client from the test setup
-		conn := testAccProvider.Meta().(service.DBApiClient)
+		conn := testAccProvider.Meta().(*service.DBApiClient)
 		resp, err := conn.SecretAcls().Read(rs.Primary.Attributes["scope"], rs.Primary.Attributes["principal"])
 		//t.Log(resp)
 		if err != nil {

--- a/databricks/resource_databricks_secret_scope.go
+++ b/databricks/resource_databricks_secret_scope.go
@@ -35,7 +35,7 @@ func resourceSecretScope() *schema.Resource {
 }
 
 func resourceSecretScopeCreate(d *schema.ResourceData, m interface{}) error {
-	client := m.(service.DBApiClient)
+	client := m.(*service.DBApiClient)
 	scopeName := d.Get("name").(string)
 	initialManagePrincipal := d.Get("initial_manage_principal").(string)
 	err := client.SecretScopes().Create(scopeName, initialManagePrincipal)
@@ -47,7 +47,7 @@ func resourceSecretScopeCreate(d *schema.ResourceData, m interface{}) error {
 }
 
 func resourceSecretScopeRead(d *schema.ResourceData, m interface{}) error {
-	client := m.(service.DBApiClient)
+	client := m.(*service.DBApiClient)
 	id := d.Id()
 	scope, err := client.SecretScopes().Read(id)
 	if err != nil {
@@ -68,7 +68,7 @@ func resourceSecretScopeRead(d *schema.ResourceData, m interface{}) error {
 }
 
 func resourceSecretScopeDelete(d *schema.ResourceData, m interface{}) error {
-	client := m.(service.DBApiClient)
+	client := m.(*service.DBApiClient)
 	id := d.Id()
 	err := client.SecretScopes().Delete(id)
 	return err

--- a/databricks/resource_databricks_secret_scope_test.go
+++ b/databricks/resource_databricks_secret_scope_test.go
@@ -42,7 +42,7 @@ func TestAccSecretScopeResource(t *testing.T) {
 			},
 			{
 				PreConfig: func() {
-					client := testAccProvider.Meta().(service.DBApiClient)
+					client := testAccProvider.Meta().(*service.DBApiClient)
 					err := client.SecretScopes().Delete(scope)
 					assert.NoError(t, err, err)
 				},
@@ -64,7 +64,7 @@ func TestAccSecretScopeResource(t *testing.T) {
 }
 
 func testSecretScopeResourceDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(service.DBApiClient)
+	client := testAccProvider.Meta().(*service.DBApiClient)
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "databricks_secret_scope" {
 			continue
@@ -96,7 +96,7 @@ func testSecretScopeResourceExists(n string, secretScope *model.SecretScope, t *
 		}
 
 		// retrieve the configured client from the test setup
-		conn := testAccProvider.Meta().(service.DBApiClient)
+		conn := testAccProvider.Meta().(*service.DBApiClient)
 		resp, err := conn.SecretScopes().Read(rs.Primary.ID)
 		//t.Log(resp)
 		if err != nil {

--- a/databricks/resource_databricks_secret_test.go
+++ b/databricks/resource_databricks_secret_test.go
@@ -47,7 +47,7 @@ func TestAccSecretResource(t *testing.T) {
 			{
 				//Deleting and recreating the secret
 				PreConfig: func() {
-					client := testAccProvider.Meta().(service.DBApiClient)
+					client := testAccProvider.Meta().(*service.DBApiClient)
 					err := client.Secrets().Delete(scope, secret.Key)
 					assert.NoError(t, err, err)
 				},
@@ -68,7 +68,7 @@ func TestAccSecretResource(t *testing.T) {
 			{
 				//Deleting the scope should recreate the secret
 				PreConfig: func() {
-					client := testAccProvider.Meta().(service.DBApiClient)
+					client := testAccProvider.Meta().(*service.DBApiClient)
 					err := client.SecretScopes().Delete(scope)
 					assert.NoError(t, err, err)
 				},
@@ -91,7 +91,7 @@ func TestAccSecretResource(t *testing.T) {
 }
 
 func testSecretResourceDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(service.DBApiClient)
+	client := testAccProvider.Meta().(*service.DBApiClient)
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "databricks_secret" && rs.Type != "databricks_secret_scope" {
 			continue
@@ -127,7 +127,7 @@ func testSecretResourceExists(n string, secret *model.SecretMetadata, t *testing
 		}
 
 		// retrieve the configured client from the test setup
-		conn := testAccProvider.Meta().(service.DBApiClient)
+		conn := testAccProvider.Meta().(*service.DBApiClient)
 		resp, err := conn.Secrets().Read(rs.Primary.Attributes["scope"], rs.Primary.Attributes["key"])
 		//t.Log(resp)
 		if err != nil {

--- a/databricks/resource_databricks_token.go
+++ b/databricks/resource_databricks_token.go
@@ -47,7 +47,7 @@ func resourceToken() *schema.Resource {
 }
 
 func resourceTokenCreate(d *schema.ResourceData, m interface{}) error {
-	client := m.(service.DBApiClient)
+	client := m.(*service.DBApiClient)
 	lifeTimeSeconds := d.Get("lifetime_seconds").(int)
 	comment := d.Get("comment").(string)
 	tokenResp, err := client.Tokens().Create(int32(lifeTimeSeconds), comment)
@@ -64,7 +64,7 @@ func resourceTokenCreate(d *schema.ResourceData, m interface{}) error {
 
 func resourceTokenRead(d *schema.ResourceData, m interface{}) error {
 	id := d.Id()
-	client := m.(service.DBApiClient)
+	client := m.(*service.DBApiClient)
 	token, err := client.Tokens().Read(id)
 	if err != nil {
 		if isTokenMissing(err.Error(), id) {
@@ -84,7 +84,7 @@ func resourceTokenRead(d *schema.ResourceData, m interface{}) error {
 
 func resourceTokenDelete(d *schema.ResourceData, m interface{}) error {
 	tokenID := d.Id()
-	client := m.(service.DBApiClient)
+	client := m.(*service.DBApiClient)
 	err := client.Tokens().Delete(tokenID)
 	return err
 }

--- a/databricks/resource_databricks_token_test.go
+++ b/databricks/resource_databricks_token_test.go
@@ -43,7 +43,7 @@ func TestAccTokenResource(t *testing.T) {
 			{
 				//Deleting and recreating the token
 				PreConfig: func() {
-					client := testAccProvider.Meta().(service.DBApiClient)
+					client := testAccProvider.Meta().(*service.DBApiClient)
 					err := client.Tokens().Delete(tokenInfo.TokenID)
 					assert.NoError(t, err, err)
 				},
@@ -65,7 +65,7 @@ func TestAccTokenResource(t *testing.T) {
 }
 
 func testAccCheckTokenResourceDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(service.DBApiClient)
+	conn := testAccProvider.Meta().(*service.DBApiClient)
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "databricks_token" {
 			continue
@@ -101,7 +101,7 @@ func testAccCheckTokenResourceExists(n string, tokenInfo *model.TokenInfo, t *te
 		}
 
 		// retrieve the configured client from the test setup
-		conn := testAccProvider.Meta().(service.DBApiClient)
+		conn := testAccProvider.Meta().(*service.DBApiClient)
 		resp, err := conn.Tokens().Read(rs.Primary.ID)
 		if err != nil {
 			return err

--- a/databricks/utils.go
+++ b/databricks/utils.go
@@ -8,7 +8,7 @@ import (
 	"time"
 )
 
-func changeClusterIntoRunningState(clusterID string, client service.DBApiClient) error {
+func changeClusterIntoRunningState(clusterID string, client *service.DBApiClient) error {
 	//return nil
 	clusterInfo, err := client.Clusters().Get(clusterID)
 	if err != nil {


### PR DESCRIPTION
Fixes accidental workspace creation in #54.

Uses the CustomAuthorizer attribute in the client config to delay the token generation till an actual api call is called via performQuery. It also changes the providerConfigure to return a pointer to the client rather than the value of the client object itself. So a mutex was added to getOrCreateToken function to ensure that multiple tokens are not generated.