### PR TITLE
Fix Dockerfile compatibility with Alpine Linux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /go/src/github.com/databrickslabs/databricks-terraform/
 RUN curl -sSL "https://github.com/gotestyourself/gotestsum/releases/download/v0.4.2/gotestsum_0.4.2_linux_amd64.tar.gz" | tar -xz -C /usr/local/bin gotestsum
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.25.0
 COPY . .
-RUN make vendor build
+RUN CGO_ENABLED=0 make vendor build
 
 FROM hashicorp/terraform:latest
 COPY --from=0 /go/src/github.com/databrickslabs/databricks-terraform/terraform-provider-databricks /root/.terraform.d/plugins/


### PR DESCRIPTION
In order to support Alpine Linux the `CGO_ENABLED=0` flag is needed, which is set in `.goreleaser.yml` but was not set in the Dockerfile.

Before this change the binary built via the Dockerfile was not compatible with the hashicorp/terraform base image, which is based on Alpine Linux.

In other words this is what happened if you tried to build master and use it directly via the Dockerfile:

```
❯ git checkout master
Switched to branch 'master'
Your branch is up to date with 'origin/master'.

❯ docker build -t jordanjennings/databricks-terraform:master .
Sending build context to Docker daemon  20.83MB
Step 1/9 : FROM golang:1.13

... lots of build output removed ...

Successfully built ed0089b8fd5d
Successfully tagged jordanjennings/databricks-terraform:master

❯ docker run --rm -it --entrypoint sh jordanjennings/databricks-terraform:master

/ # ls -al ~/.terraform.d/plugins/
total 30044
drwxr-xr-x    2 root     root          4096 Jun  2 20:33 .
drwxr-xr-x    3 root     root          4096 Jun  2 20:33 ..
-rwxr-xr-x    1 root     root      30755834 Jun  2 20:33 terraform-provider-databricks

/ # ~/.terraform.d/plugins/terraform-provider-databricks 
sh: /root/.terraform.d/plugins/terraform-provider-databricks: not found

```

Here's the same thing with the `CGO_ENABLED=0` flag as included in this PR (error message as expected):

```
❯ docker run --rm -it --entrypoint sh jordanjennings/databricks-terraform:pr
/ # ~/.terraform.d/plugins/terraform-provider-databricks 
2020/06/03 14:28:39 dev, commit , built at unknown
This binary is a plugin. These are not meant to be executed directly.
Please execute the program that consumes these plugins, which will
load any plugins automatically
```

I don't know if `CGO_ENABLED=0`  is something that should instead be set in the Makefile, but setting in the Dockerfile was the more isolated way to handle it here.